### PR TITLE
Allow getting multiple items at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,12 @@ cache.set('some-key', 'some-value', ['some-tag'], { timeout: 123, })cache
   .then(() => console.log('Stored successfully!'))
 ```
 
-### cache.get(key)
+### cache.get(...keys)
 
-Get a record from the cache. Usage:
+Get records from the cache. Usage:
 
 ```JS
-cache.get(key: string): Promise<?value>
+cache.get(...keys: Array<string>): Promise<Array<?value> | ?value>
 ```
 
 #### Example
@@ -127,6 +127,9 @@ cache.get('existing-key')
 
 cache.get('not-existing-key')
   .then(data => console.log('data is null', data === null));
+
+cache.get('key-1', 'key-2')
+  .then(data => console.log('got multiple keys', data[0], data[1]));
 ```
 
 ### cache.invalidate(...tags)

--- a/src/index.js
+++ b/src/index.js
@@ -26,11 +26,13 @@ class TagCache {
     this.options = options;
   }
 
-  get = async (key: string): Promise<?CacheData> => {
+  get = async (...keys: Array<string>): Promise<?CacheData> => {
     try {
-      return this.redis.get(`data:${key}`).then(res => {
+      return this.redis.mget(keys.map(key => `data:${key}`)).then(res => {
         try {
-          return JSON.parse(res);
+          // Special case for single element gets
+          if (res.length === 1) return JSON.parse(res[0]);
+          return res.map(elem => JSON.parse(elem));
         } catch (err) {
           return res;
         }

--- a/src/test/tag-cache.test.js
+++ b/src/test/tag-cache.test.js
@@ -22,6 +22,13 @@ it('should get and set items', async () => {
   expect(await cache.get('a')).toEqual('data');
 });
 
+it('should get multiple items', async () => {
+  const cache = new TagCache();
+  await cache.set('a', 'data-a', ['some-tag']);
+  await cache.set('b', 'data-b', ['some-tag']);
+  expect(await cache.get('a', 'b')).toEqual(['data-a', 'data-b']);
+});
+
 it('should invalidate an item with a tag', async () => {
   const cache = new TagCache();
   await cache.set('a', 'data', ['tag-1']);


### PR DESCRIPTION
Switches from using redis.get to using redis.mget. This should make it possible to implement a dataloader-like solution on top.